### PR TITLE
add instruction to disable dinghy DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,12 @@ the dev wanted to have some containers accessible at `something.docker` and `ano
 you need to disable dinghy's proxy stuff (otherwise dinghy and dory will stomp on each other's resolv files):
 
 In your [`~/.dinghy/preferences.yml`](https://github.com/codekitchen/dinghy#preferences)
-file, disable the proxy:
+file, disable the proxy and resolver:
 
 ```yaml
 :preferences:
   :proxy_disabled: true
+  :dns_disabled: true
   ...
 ```
 


### PR DESCRIPTION
without also disabling dinghy's DNS, you still end up with the dinghy resolver and `dinghy_http_proxy` container.  this doesn't seem to cause conflicts, but it's unnecessary, so it may as well be disabled.